### PR TITLE
Add Transporter and Snap Client

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,29 @@
+package snap
+
+import "encoding/json"
+
+type retrier interface {
+	canRetry() bool
+}
+
+type redacter interface {
+	redact() error
+}
+
+type RawError struct {
+	Code    string `json:"responseCode"`
+	Message string `json:"responseMessage"`
+}
+
+func (e *RawError) Error() string {
+	ret, _ := json.Marshal(e)
+	return string(ret)
+}
+
+func (e *RawError) redact() error {
+	return e
+}
+
+func (e *RawError) canRetry() bool {
+	return false
+}

--- a/form/form.go
+++ b/form/form.go
@@ -1,0 +1,634 @@
+package form
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Values is a collection of values that can be submitted along with a
+// request that specifically allows for duplicate keys and encodes its entries
+// in the same order that they were added.
+type Values struct {
+	values []formValue
+}
+
+// Add adds a key/value tuple to the form.
+func (f *Values) Add(key, val string) {
+	f.values = append(f.values, formValue{key, val})
+}
+
+// Encode encodes the keys and values into URL encoded form
+// ("bar=baz&foo=quux").
+func (f *Values) Encode() string {
+	if f == nil {
+		return ""
+	}
+	var buf bytes.Buffer
+	for _, v := range f.values {
+		if buf.Len() > 0 {
+			buf.WriteByte('&')
+		}
+		key := url.QueryEscape(v.Key)
+		key = strings.ReplaceAll(key, "%5B", "[")
+		key = strings.ReplaceAll(key, "%5D", "]")
+		buf.WriteString(key)
+		buf.WriteString("=")
+		buf.WriteString(url.QueryEscape(v.Value))
+	}
+	return buf.String()
+}
+
+// Empty returns true if no parameters have been set.
+func (f *Values) Empty() bool {
+	return len(f.values) == 0
+}
+
+// Set sets the first instance of a parameter for the given key to the given
+// value. If no parameters exist with the key, a new one is added.
+//
+// Note that Set is O(n) and may be quite slow for a very large parameter list.
+func (f *Values) Set(key, val string) {
+	for i, v := range f.values {
+		if v.Key == key {
+			f.values[i].Value = val
+			return
+		}
+	}
+
+	f.Add(key, val)
+}
+
+// Get retrieves the list of values for the given key.  If no values exist
+// for the key, nil will be returned.
+//
+// Note that Get is O(n) and may be quite slow for a very large parameter list.
+func (f *Values) Get(key string) []string {
+	var results []string
+	for i, v := range f.values {
+		if v.Key == key {
+			results = append(results, f.values[i].Value)
+		}
+	}
+	return results
+}
+
+// ToValues converts an instance of Values into an instance of
+// url.Values. This can be useful in cases where it's useful to make an
+// unordered comparison of two sets of request values.
+//
+// Note that url.Values is incapable of representing certain Rack form types in
+// a cohesive way. For example, an array of maps in Rack is encoded with a
+// string like:
+//
+//	arr[][foo]=foo0&arr[][bar]=bar0&arr[][foo]=foo1&arr[][bar]=bar1
+//
+// Because url.Values is a map, values will be handled in a way that's grouped
+// by their key instead of in the order they were added. Therefore the above
+// may by encoded to something like (maps are unordered so the actual result is
+// somewhat non-deterministic):
+//
+//	arr[][foo]=foo0&arr[][foo]=foo1&arr[][bar]=bar0&arr[][bar]=bar1
+//
+// And thus result in an incorrect request.
+func (f *Values) ToValues() url.Values {
+	values := url.Values{}
+	for _, v := range f.values {
+		values.Add(v.Key, v.Value)
+	}
+	return values
+}
+
+// A key/value tuple for use in the Values type.
+type formValue struct {
+	Key   string
+	Value string
+}
+
+// FormatKey takes a series of key parts that may be parameter keyParts, map keys,
+// or array indices and unifies them into a single key suitable for Snap's
+// style of form encoding.
+func FormatKey(parts []string) string {
+	if len(parts) < 1 {
+		panic("Not allowed 0-length parts slice")
+	}
+
+	key := parts[0]
+	for i := 1; i < len(parts); i++ {
+		key += "[" + parts[i] + "]"
+	}
+	return key
+}
+
+// AppendTo uses reflection to form encode into the given values collection
+// based off the form tags that it defines.
+func AppendTo(values *Values, i interface{}) {
+	reflectValue(values, reflect.ValueOf(i), false, nil)
+}
+
+// Appender is the interface implemented by types that can append themselves to
+// a collection of form values.
+//
+// This is usually something that shouldn't be used, but is needed in a few
+// places where authors deviated from norms while implementing various
+// parameters.
+type Appender interface {
+	// AppendTo is invoked by the form package on any types found to implement
+	// Appender so that they have a chance to encode themselves. Note that
+	// AppendTo is called in addition to normal encoding, so other form tags on
+	// the struct are still fair game.
+	AppendTo(values *Values, keyParts []string)
+}
+
+func isAppender(t reflect.Type) bool {
+	return t.Implements(reflect.TypeOf((*Appender)(nil)).Elem())
+}
+
+// reflectValue is roughly the shared entry point of any AppendTo functions.
+// It's also called recursively in cases where a precise type isn't yet known
+// and its encoding needs to be deferred down the chain; for example, when
+// encoding interface{} or the values in an array or map containing
+// interface{}.
+func reflectValue(values *Values, v reflect.Value, encodeZero bool, keyParts []string) {
+	t := v.Type()
+
+	f := getCachedOrBuildTypeEncoder(t)
+	if f != nil {
+		f(values, v, keyParts, encodeZero || v.Kind() == reflect.Ptr, nil)
+	}
+
+	if isAppender(t) {
+		v.Interface().(Appender).AppendTo(values, keyParts)
+	}
+}
+
+type formOptions struct {
+	// Empty indicates that a field's value should be emptied in that its value
+	// should be an empty string. It's used to workaround the fact that an
+	// empty string is a string's zero value and wouldn't normally be encoded.
+	Empty bool
+
+	// HighPrecision indicates that this field should be treated as a high
+	// precision decimal, a decimal whose precision is important to the API and
+	// which we want to encode as accurately as possible.
+	//
+	// All parameters are encoded using form encoding, so this of course
+	// encodes a value to a string, but notably, these high precision fields
+	// are sent back as strings in JSON, even though they might be surfaced as
+	// floats in this library.
+	//
+	// This isn't a perfect abstraction because floats are not precise in
+	// nature, and we might be better-advised to use a real high-precision data
+	// type like `big.Float`. That said, we suspect that this will be an
+	// adequate solution in the vast majority of cases and has a usability
+	// benefit, so we've gone this route.
+	HighPrecision bool
+}
+
+// encoderFunc is used to encode any type from a request.
+//
+// A note about encodeZero: Since some types in the Snap API are defaulted to
+// non-zero values, and Go defaults types to their zero values, any type that
+// has a Snap API default of a non-zero value is defined as a Go pointer,
+// meaning nil defaults to the Snap API non-zero value. To override this, a
+// check is made to see if the value is the zero-value for that type. If it is
+// and encodeZero is true, it's encoded. This is ignored as a parameter when
+// dealing with types like structs, where the decision cannot be made
+// preemptively.
+type encoderFunc func(values *Values, v reflect.Value, keyParts []string, encodeZero bool, options *formOptions)
+
+var encoderCache struct {
+	m  map[reflect.Type]encoderFunc
+	mu sync.RWMutex // for coordinating concurrent operations on m
+}
+
+// getCachedOrBuildTypeEncoder tries to get an encoderFunc for the type from
+// the cache, and falls back to building one if there wasn't a cached one
+// available. If an encoder is built, it's stored back to the cache.
+func getCachedOrBuildTypeEncoder(t reflect.Type) encoderFunc {
+	// Just acquire a read lock when extracting a value (note that in Go, a map
+	// cannot be read while it's also being written).
+	encoderCache.mu.RLock()
+	f := encoderCache.m[t]
+	encoderCache.mu.RUnlock()
+
+	if f != nil {
+		return f
+	}
+
+	// We do the work to get the encoder without holding a lock. This could
+	// result in duplicate work, but it will help us avoid a deadlock. Encoders
+	// may be built and stored recursively in the cases of something like an
+	// array or slice, so we need to make sure that this function is properly
+	// re-entrant.
+	f = makeTypeEncoder(t)
+
+	encoderCache.mu.Lock()
+	defer encoderCache.mu.Unlock()
+
+	if encoderCache.m == nil {
+		encoderCache.m = make(map[reflect.Type]encoderFunc)
+	}
+	encoderCache.m[t] = f
+
+	return f
+}
+
+func timeEncoder(values *Values, v reflect.Value, keyParts []string, encodeZero bool, _ *formOptions) {
+	val := v.Interface().(time.Time)
+	if val.IsZero() && !encodeZero {
+		return
+	}
+	values.Add(FormatKey(keyParts), val.String())
+}
+
+func buildArrayOrSliceEncoder(t reflect.Type) encoderFunc {
+	// Gets an encoder for the type that the array or slice will hold
+	elemF := getCachedOrBuildTypeEncoder(t.Elem())
+
+	return func(values *Values, v reflect.Value, keyParts []string, _ bool, options *formOptions) {
+		// When encountering a slice that's been explicitly set (i.e. non-nil)
+		// and which is of 0 length, we take this as an indication that the
+		// user is trying to zero the API array. See the `additional_owners`
+		// property under `legal_entity` on account for an example of somewhere
+		// that this is useful.
+		//
+		// This only works for a slice (and not an array) because even a zeroed
+		// array always has a fixed length.
+		if t.Kind() == reflect.Slice && !v.IsNil() && v.Len() == 0 {
+			values.Add(FormatKey(keyParts), "")
+			return
+		}
+
+		var arrNames []string
+
+		for i := 0; i < v.Len(); i++ {
+			arrNames = append(keyParts, strconv.Itoa(i))
+
+			indexV := v.Index(i)
+			elemF(values, indexV, arrNames, indexV.Kind() == reflect.Ptr, nil)
+
+			if isAppender(indexV.Type()) && !indexV.IsNil() {
+				indexV.Interface().(Appender).AppendTo(values, arrNames)
+			}
+		}
+	}
+}
+
+func boolEncoder(values *Values, v reflect.Value, keyParts []string, encodeZero bool, options *formOptions) {
+	val := v.Bool()
+	if !val && !encodeZero {
+		return
+	}
+
+	if options != nil {
+		switch {
+		case options.Empty:
+			values.Add(FormatKey(keyParts), "")
+		}
+	} else {
+		values.Add(FormatKey(keyParts), strconv.FormatBool(val))
+	}
+}
+
+func float32Encoder(values *Values, v reflect.Value, keyParts []string, encodeZero bool, options *formOptions) {
+	val := v.Float()
+	if val == 0.0 && !encodeZero {
+		return
+	}
+	prec := 4
+	if options != nil && options.HighPrecision {
+		// Special value that tells Go to format the float in as few required
+		// digits as necessary for it to be successfully parsable from a string
+		// back to the same original number.
+		prec = -1
+	}
+	values.Add(FormatKey(keyParts), strconv.FormatFloat(val, 'f', prec, 32))
+}
+
+func float64Encoder(values *Values, v reflect.Value, keyParts []string, encodeZero bool, options *formOptions) {
+	val := v.Float()
+	if val == 0.0 && !encodeZero {
+		return
+	}
+	prec := 4
+	if options != nil && options.HighPrecision {
+		// Special value that tells Go to format the float in as few required
+		// digits as necessary for it to be successfully parsable from a string
+		// back to the same original number.
+		prec = -1
+	}
+	values.Add(FormatKey(keyParts), strconv.FormatFloat(val, 'f', prec, 64))
+}
+
+func intEncoder(values *Values, v reflect.Value, keyParts []string, encodeZero bool, options *formOptions) {
+	val := v.Int()
+	if val == 0 && !encodeZero {
+		return
+	}
+	values.Add(FormatKey(keyParts), strconv.FormatInt(val, 10))
+}
+
+func interfaceEncoder(values *Values, v reflect.Value, keyParts []string, encodeZero bool, _ *formOptions) {
+	// interfaceEncoder never encodes a `nil`, but it will pass through an
+	// `encodeZero` value into its chained encoder
+	if v.IsNil() {
+		return
+	}
+	reflectValue(values, v.Elem(), encodeZero, keyParts)
+}
+
+// Strict enables strict mode wherein the package will panic on an AppendTo
+// function if it finds that a tag string was malformed.
+var Strict = false
+
+func mapEncoder(values *Values, v reflect.Value, keyParts []string, _ bool, _ *formOptions) {
+	keys := make([]string, 0, v.Len())
+	for _, keyVal := range v.MapKeys() {
+		if keyVal.Kind() != reflect.String {
+			if Strict {
+				panic("Don't support serializing maps with non-string keys")
+			}
+			// otherwise keyVal.String() will panic later
+			continue
+		}
+		keys = append(keys, keyVal.String())
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		// Unlike a property on a struct which will contain a zero value even
+		// if never set, any value found in a map has been explicitly set, so
+		// we always make an effort to encode them, even if a zero value
+		// (that's why we pass through `true` here).
+		reflectValue(values, v.MapIndex(reflect.ValueOf(key)), true, append(keyParts, key))
+	}
+}
+
+func stringEncoder(values *Values, v reflect.Value, keyParts []string, encodeZero bool, options *formOptions) {
+	val := v.String()
+	if val == "" && !encodeZero {
+		return
+	}
+	values.Add(FormatKey(keyParts), val)
+}
+
+func uintEncoder(values *Values, v reflect.Value, keyParts []string, encodeZero bool, options *formOptions) {
+	val := v.Uint()
+	if val == 0 && !encodeZero {
+		return
+	}
+	values.Add(FormatKey(keyParts), strconv.FormatUint(val, 10))
+}
+
+func buildPtrEncoder(t reflect.Type) encoderFunc {
+	// Gets an encoder for the type that the pointer wraps
+	elemF := getCachedOrBuildTypeEncoder(t.Elem())
+
+	return func(values *Values, v reflect.Value, keyParts []string, _ bool, options *formOptions) {
+		// We take a nil to mean that the property wasn't set, so ignore it in
+		// the final encoding.
+		if v.IsNil() {
+			return
+		}
+
+		// Handle "zeroing" an array stored as a pointer to a slice. See
+		// comment in `buildArrayOrSliceEncoder` above.
+		if t.Elem().Kind() == reflect.Slice && v.Elem().Len() == 0 {
+			values.Add(FormatKey(keyParts), "")
+			return
+		}
+
+		// Otherwise, call into the appropriate encoder for the pointer's type.
+		elemF(values, v.Elem(), keyParts, true, options)
+	}
+}
+
+func buildStructEncoder(t reflect.Type) encoderFunc {
+	se := getCachedOrBuildStructEncoder(t)
+	return se.encode
+}
+
+// field represents a single field found in a struct. It caches information
+// about that field so that we can make encoding faster.
+type field struct {
+	formName   string
+	index      int
+	isAppender bool
+	isPtr      bool
+	options    *formOptions
+}
+
+type structEncoder struct {
+	fields    []*field
+	fieldEncs []encoderFunc
+}
+
+func (se *structEncoder) encode(values *Values, v reflect.Value, keyParts []string, _ bool, _ *formOptions) {
+	for i, f := range se.fields {
+		var fieldKeyParts []string
+		fieldV := v.Field(f.index)
+
+		// The wildcard on a form tag is a "special" value: it indicates a
+		// struct field that we should recurse into, but for which no part
+		// should be added to the key parts, meaning that its own subfields
+		// will be named at the same level as with the fields of the
+		// current structure.
+		if f.formName == "*" {
+			fieldKeyParts = keyParts
+		} else {
+			fieldKeyParts = append(keyParts, f.formName)
+		}
+
+		se.fieldEncs[i](values, fieldV, fieldKeyParts, f.isPtr, f.options)
+		if f.isAppender && (!f.isPtr || !fieldV.IsNil()) {
+			fieldV.Interface().(Appender).AppendTo(values, fieldKeyParts)
+		}
+	}
+}
+
+var structCache struct {
+	m  map[reflect.Type]*structEncoder
+	mu sync.RWMutex // for coordinating concurrent operations on m
+}
+
+func getCachedOrBuildStructEncoder(t reflect.Type) *structEncoder {
+	// Just acquire a read lock when extracting a value (note that in Go, a map
+	// cannot be read while it's also being written).
+	structCache.mu.RLock()
+	f := structCache.m[t]
+	structCache.mu.RUnlock()
+
+	if f != nil {
+		return f
+	}
+
+	// We do the work to get the encoder without holding a lock. This could
+	// result in duplicate work, but it will help us avoid a deadlock. Encoders
+	// may be built and stored recursively in the cases of something like an
+	// array or slice, so we need to make sure that this function is properly
+	// re-entrant.
+	f = makeStructEncoder(t)
+
+	structCache.mu.Lock()
+	defer structCache.mu.Unlock()
+
+	if structCache.m == nil {
+		structCache.m = make(map[reflect.Type]*structEncoder)
+	}
+	structCache.m[t] = f
+
+	return f
+}
+
+func parseTag(tag string) (string, *formOptions) {
+	var options *formOptions
+	parts := strings.Split(tag, ",")
+	name := parts[0]
+
+	for i := 1; i < len(parts); i++ {
+		switch parts[i] {
+		case "empty":
+			if options == nil {
+				options = &formOptions{}
+			}
+			options.Empty = true
+
+		case "high_precision":
+			if options == nil {
+				options = &formOptions{}
+			}
+			options.HighPrecision = true
+
+		default:
+			if Strict {
+				part := parts[i]
+				if part == "" {
+					part = "(empty)"
+				}
+				panic(fmt.Sprintf("Don't know how to handle form tag part: %s (tag: %s)",
+					part, tag))
+			}
+		}
+	}
+
+	return name, options
+}
+
+func makeTypeEncoder(t reflect.Type) encoderFunc {
+	// For time.Time, we want to encode imediately it as a Unix timestamp,
+	// and don't want to inspect into it and encode it as a struct.
+	if t == reflect.TypeOf(time.Time{}) {
+		return timeEncoder
+	}
+
+	switch t.Kind() {
+	case reflect.Array, reflect.Slice:
+		return buildArrayOrSliceEncoder(t)
+
+	case reflect.Bool:
+		return boolEncoder
+
+	case reflect.Float32:
+		return float32Encoder
+
+	case reflect.Float64:
+		return float64Encoder
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return intEncoder
+
+	case reflect.Interface:
+		return interfaceEncoder
+
+	case reflect.Map:
+		return mapEncoder
+
+	case reflect.Ptr:
+		return buildPtrEncoder(t)
+
+	case reflect.String:
+		return stringEncoder
+
+	case reflect.Struct:
+		return buildStructEncoder(t)
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return uintEncoder
+	}
+
+	return nil
+}
+
+const tagName = "form"
+
+func makeStructEncoder(t reflect.Type) *structEncoder {
+	// Don't specify capacity because we don't know how many fields are tagged with
+	// `form`
+	se := &structEncoder{}
+
+	for i := 0; i < t.NumField(); i++ {
+		reflectField := t.Field(i)
+		tag := reflectField.Tag.Get(tagName)
+		if Strict && tag == "" {
+			panic(fmt.Sprintf(
+				"All fields in structs to be form-encoded must have `form` tag; on: %s/%s "+
+					"(hint: use an explicit `form:\"-\"` if the field should not be encoded",
+				t.Name(), reflectField.Name,
+			))
+		}
+
+		formName, options := parseTag(tag)
+
+		// Like with encoding/json, a hyphen is an explicit way of saying
+		// that this field should not be encoded
+		if formName == "-" {
+			continue
+		}
+
+		fldTyp := reflectField.Type
+		fldKind := fldTyp.Kind()
+
+		if Strict && options != nil {
+			if options.Empty && fldKind != reflect.Bool {
+				panic(fmt.Sprintf(
+					"Cannot specify `empty` for non-boolean field; on: %s/%s",
+					t.Name(), reflectField.Name,
+				))
+			}
+
+			var k reflect.Kind
+			if fldKind == reflect.Ptr {
+				k = fldTyp.Elem().Kind()
+			} else {
+				k = fldKind
+			}
+
+			fldIsFloat := k == reflect.Float32 || k == reflect.Float64
+
+			if options.HighPrecision && !fldIsFloat {
+				panic(fmt.Sprintf(
+					"Cannot specify `high_precision` for non-float field; on: %s/%s (%s)",
+					t.Name(), reflectField.Name, fldTyp,
+				))
+			}
+		}
+
+		se.fields = append(se.fields, &field{
+			formName:   formName,
+			index:      i,
+			isAppender: isAppender(fldTyp),
+			isPtr:      fldKind == reflect.Ptr,
+			options:    options,
+		})
+		se.fieldEncs = append(se.fieldEncs,
+			getCachedOrBuildTypeEncoder(fldTyp))
+	}
+
+	return se
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/DoWithLogic/snap/v1
+
+go 1.23.2

--- a/log.go
+++ b/log.go
@@ -1,0 +1,138 @@
+package snap
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	// LevelNull sets a logger to show no messages at all.
+	LevelNull Level = 0
+
+	// LevelError sets a logger to show error messages only.
+	LevelError Level = 1
+
+	// LevelWarn sets a logger to show warning messages or anything more
+	// severe.
+	LevelWarn Level = 2
+
+	// LevelInfo sets a logger to show informational messages or anything more
+	// severe.
+	LevelInfo Level = 3
+
+	// LevelDebug sets a logger to show informational messages or anything more
+	// severe.
+	LevelDebug Level = 4
+)
+
+//
+// Public variables
+//
+
+// DefaultLeveledLogger is the default logger that the library will use to log
+// errors, warnings, and informational messages.
+//
+// LeveledLoggerInterface is implemented by LeveledLogger, and one can be
+// initialized at the desired level of logging.  LeveledLoggerInterface also
+// provides out-of-the-box compatibility with a Logrus Logger, but may require
+// a thin shim for use with other logging libraries that use less standard
+// conventions like Zap.
+//
+// This Logger will be inherited by any backends created by default, but will
+// be overridden if a backend is created with GetBackendWithConfig with a
+// custom LeveledLogger set.
+var DefaultLeveledLogger LeveledLoggerInterface = &LeveledLogger{
+	Level: LevelError,
+}
+
+//
+// Public types
+//
+
+// Level represents a logging level.
+type Level uint32
+
+// LeveledLogger is a leveled logger implementation.
+//
+// It prints warnings and errors to `os.Stderr` and other messages to
+// `os.Stdout`.
+type LeveledLogger struct {
+	// Level is the minimum logging level that will be emitted by this logger.
+	//
+	// For example, a Level set to LevelWarn will emit warnings and errors, but
+	// not informational or debug messages.
+	//
+	// Always set this with a constant like LevelWarn because the individual
+	// values are not guaranteed to be stable.
+	Level Level
+
+	// Internal testing use only.
+	stderrOverride io.Writer
+	stdoutOverride io.Writer
+}
+
+// Debugf logs a debug message using Printf conventions.
+func (l *LeveledLogger) Debugf(format string, v ...interface{}) {
+	if l.Level >= LevelDebug {
+		fmt.Fprintf(l.stdout(), "[DEBUG] "+format+"\n", v...)
+	}
+}
+
+// Errorf logs a warning message using Printf conventions.
+func (l *LeveledLogger) Errorf(format string, v ...interface{}) {
+	// Infof logs a debug message using Printf conventions.
+	if l.Level >= LevelError {
+		fmt.Fprintf(l.stderr(), "[ERROR] "+format+"\n", v...)
+	}
+}
+
+// Infof logs an informational message using Printf conventions.
+func (l *LeveledLogger) Infof(format string, v ...interface{}) {
+	if l.Level >= LevelInfo {
+		fmt.Fprintf(l.stdout(), "[INFO] "+format+"\n", v...)
+	}
+}
+
+// Warnf logs a warning message using Printf conventions.
+func (l *LeveledLogger) Warnf(format string, v ...interface{}) {
+	if l.Level >= LevelWarn {
+		fmt.Fprintf(l.stderr(), "[WARN] "+format+"\n", v...)
+	}
+}
+
+func (l *LeveledLogger) stderr() io.Writer {
+	if l.stderrOverride != nil {
+		return l.stderrOverride
+	}
+
+	return os.Stderr
+}
+
+func (l *LeveledLogger) stdout() io.Writer {
+	if l.stdoutOverride != nil {
+		return l.stdoutOverride
+	}
+
+	return os.Stdout
+}
+
+// LeveledLoggerInterface provides a basic leveled logging interface for
+// printing debug, informational, warning, and error messages.
+//
+// It's implemented by LeveledLogger and also provides out-of-the-box
+// compatibility with a Logrus Logger, but may require a thin shim for use with
+// other logging libraries that you use less standard conventions like Zap.
+type LeveledLoggerInterface interface {
+	// Debugf logs a debug message using Printf conventions.
+	Debugf(format string, v ...interface{})
+
+	// Errorf logs a warning message using Printf conventions.
+	Errorf(format string, v ...interface{})
+
+	// Infof logs an informational message using Printf conventions.
+	Infof(format string, v ...interface{})
+
+	// Warnf logs a warning message using Printf conventions.
+	Warnf(format string, v ...interface{})
+}

--- a/params.go
+++ b/params.go
@@ -1,0 +1,98 @@
+package snap
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/DoWithLogic/snap/v1/form"
+)
+
+// Contains constants for the names of parameters used for pagination in list APIs
+const (
+	EndingBefore  = "ending_before"
+	StartingAfter = "starting_after"
+)
+
+// ExtraValues are extra parameters that are attached to an API request.
+// They're implemented as a custom type so that they can have their own
+// AppendTo implementation.
+type ExtraValues struct {
+	url.Values `form:"-" json:"-"` // See custom AppendTo implementation
+}
+
+// AppendTo implements custom form encoding for extra parameter values.
+func (v ExtraValues) AppendTo(body *form.Values, keyParts []string) {
+	for k, vs := range v.Values {
+		for _, v := range vs {
+			body.Add(form.FormatKey(append(keyParts, k)), v)
+		}
+	}
+}
+
+// Filters is a structure that contains a collection of filters for list-related APIs.
+type Filters struct {
+	f []*filter
+}
+
+// AddFilter adds a new filter with a given key, op and value.
+func (f *Filters) AddFilter(key, op, value string) {
+	f.f = append(f.f, &filter{Key: key, Op: op, Val: value})
+}
+
+type filter struct {
+	Key, Op, Val string `form:"-" json:"-"`
+}
+
+// Params is the structure that contains the common properties
+// of any *Params structure.
+type Params struct {
+	// Context used for request. It may carry deadlines, cancelation signals,
+	// and other request-scoped values across API boundaries and between
+	// processes.
+	//
+	// Note that a cancelled or timed out context does not provide any
+	// guarantee whether the operation was or was not completed on Snap's API
+	// servers. For certainty, you must either retry with the same idempotency
+	// key or query the state of the API.
+	Context context.Context `form:"-" json:"-"`
+
+	Extra *ExtraValues `form:"*"  json:"-"`
+
+	// Headers may be used to provide extra header lines on the HTTP request.
+	Headers http.Header `form:"-" json:"-"`
+
+	// Deprecated: Please use Metadata in the surrounding struct instead.
+	Metadata map[string]string `form:"metadata" json:"-"`
+
+	usage []string `form:"-" json:"-"` // Tracked behaviors
+}
+
+// ParamsContainer is a general interface for which all parameter structs
+// should comply. They achieve this by embedding a Params struct and inheriting
+// its implementation of this interface.
+type ParamsContainer interface {
+	GetParams() *Params
+}
+
+// InternalSetUsage sets the usage field on the Params struct, removing duplicates.
+// Unstable: for internal Snap-go usage only.
+func (p *Params) InternalSetUsage(usage []string) {
+	// Optimization for nil or empty usage
+	if len(usage) == 0 {
+		return
+	}
+
+	// Use a map to track unique usage values
+	usageMap := make(map[string]struct{})
+	for _, u := range p.usage {
+		usageMap[u] = struct{}{}
+	}
+	for _, u := range usage {
+		usageMap[u] = struct{}{}
+	}
+	p.usage = p.usage[:0] // Reset the slice to avoid retaining old values
+	for u := range usageMap {
+		p.usage = append(p.usage, u)
+	}
+}

--- a/snap.go
+++ b/snap.go
@@ -1,0 +1,619 @@
+package snap
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/DoWithLogic/snap/v1/form"
+)
+
+// Transporter is an interface for making calls against a SNAP Service.
+// This interface exists to enable mocking for during testing if needed.
+type Transporter interface {
+	Call(method, path, key string, params ParamsContainer, response ResponseSetter) error
+	CallRaw(method, path, key string, body []byte, params *Params, v ResponseSetter) error
+	SetMaxNetworkRetries(maxNetworkRetries int64)
+}
+
+// APIResponse encapsulates some common features of a response from the
+type APIResponse struct {
+	// Header contain a map of all HTTP header keys to values. Its behavior and
+	// caveats are identical to that of http.Header.
+	Header http.Header
+
+	// RawJSON contains the response body as raw bytes.
+	RawJSON []byte
+
+	// RequestID contains a string that uniquely identifies the request.
+	// Used for debugging or support purposes.
+	RequestID string
+
+	// Status is a status code and message. e.g. "200 OK"
+	Status string
+
+	// StatusCode is a status code as integer. e.g. 200
+	StatusCode int
+
+	duration *time.Duration
+}
+
+// SupportedFeature is an enumeration of supported SNAP endpoints.
+type SupportedFeature string
+
+const (
+	Authorization SupportedFeature = "authorization"
+	Registration  SupportedFeature = "registeration"
+)
+
+// requestMetrics contains the id and duration of the last request sent
+type requestMetrics struct {
+	RequestDurationMS *int     `json:"request_duration_ms"`
+	RequestID         string   `json:"request_id"`
+	Usage             []string `json:"usage"`
+}
+
+// requestTelemetry contains the payload sent in the
+// `X-Snap-Client-Telemetry` header when TransporterConfig.EnableTelemetry = true.
+type requestTelemetry struct {
+	LastRequestMetrics requestMetrics `json:"last_request_metrics"`
+}
+
+// transporterImplementation is the internal implementation for making HTTP calls
+type transporterImplementation struct {
+	Type              SupportedFeature
+	URL               string
+	HTTPClient        *http.Client
+	LeveledLogger     LeveledLoggerInterface
+	MaxNetworkRetries int64
+
+	enableTelemetry bool
+
+	// networkRetriesSleep indicates whether the transporter should use the normal
+	// sleep between retries.
+	//
+	// See also SetNetworkRetriesSleep.
+	networkRetriesSleep bool
+
+	requestMetricsBuffer chan requestMetrics
+}
+
+// the snap API only accepts GET / POST
+func validateMethod(method string) error {
+	if method != http.MethodPost && method != http.MethodGet && method != http.MethodDelete {
+		return fmt.Errorf("method must be POST or GET. Received %s", method)
+	}
+	return nil
+}
+
+func extractParams(params ParamsContainer) (*form.Values, *Params, error) {
+	var formValues *form.Values
+	var commonParams *Params
+
+	if params != nil {
+		// This is a little unfortunate, but Go makes it impossible to compare
+		// an interface value to nil without the use of the reflect package and
+		// its true disciples insist that this is a feature and not a bug.
+		//
+		// Here we do invoke reflect because
+		// (1) we have to reflect anyway to use encode with the form package, and
+		// (2) the corresponding removal of boilerplate that this enables makes the small performance penalty worth it.
+		reflectValue := reflect.ValueOf(params)
+
+		if reflectValue.Kind() == reflect.Ptr && !reflectValue.IsNil() {
+			commonParams = params.GetParams()
+			formValues = &form.Values{}
+			form.AppendTo(formValues, params)
+		}
+	}
+	return formValues, commonParams, nil
+}
+
+func newAPIResponse(res *http.Response, resBody []byte, requestDuration *time.Duration) *APIResponse {
+	return &APIResponse{
+		Header:     res.Header,
+		RawJSON:    resBody,
+		RequestID:  res.Header.Get("Request-Id"),
+		Status:     res.Status,
+		StatusCode: res.StatusCode,
+		duration:   requestDuration,
+	}
+}
+
+// nopReadCloser's sole purpose is to give us a way to turn an `io.Reader` into
+// an `io.ReadCloser` by adding a no-op implementation of the `Closer`
+// interface. We need this because `http.Request`'s `Body` takes an
+// `io.ReadCloser` instead of a `io.Reader`.
+type nopReadCloser struct {
+	io.Reader
+}
+
+func (nopReadCloser) Close() error { return nil }
+
+func resetBodyReader(body *bytes.Buffer, req *http.Request) {
+	// This might look a little strange, but we set the request's body
+	// outside of `NewRequest` so that we can get a fresh version every
+	// time.
+	//
+	// The background is that back in the era of old style HTTP, it was
+	// safe to reuse `Request` objects, but with the addition of HTTP/2,
+	// it's now only sometimes safe. Reusing a `Request` with a body will
+	// break.
+	//
+	// See some details here:
+	//
+	//     https://github.com/golang/go/issues/19653#issuecomment-341539160
+	//
+	// To workaround the problem, we put a fresh `Body` onto the `Request`
+	// every time we execute it, and this seems to empirically resolve the
+	// problem.
+	if body != nil {
+		// We can safely reuse the same buffer that we used to encode our body,
+		// but return a new reader to it everytime so that each read is from
+		// the beginning.
+		reader := bytes.NewReader(body.Bytes())
+
+		req.Body = nopReadCloser{reader}
+
+		// And also add the same thing to `Request.GetBody`, which allows
+		// `net/http` to get a new body in cases like a redirect. This is
+		// usually not used, but it doesn't hurt to set it in case it's
+		// needed.
+		req.GetBody = func() (io.ReadCloser, error) {
+			reader := bytes.NewReader(body.Bytes())
+			return nopReadCloser{reader}, nil
+		}
+	}
+}
+
+func (t *transporterImplementation) Call(method, path, key string, params ParamsContainer, response ResponseSetter) error {
+	_, commonParams, err := extractParams(params)
+	if err != nil {
+		return err
+	}
+
+	var body []byte
+	if params != nil && !(reflect.ValueOf(params).Kind() == reflect.Ptr && reflect.ValueOf(params).IsNil()) {
+		body, err = json.Marshal(params)
+		if err != nil {
+			return err
+		}
+	}
+
+	return t.CallRaw(method, path, key, body, commonParams, response)
+}
+
+func (t *transporterImplementation) CallRaw(method, path, key string, body []byte, params *Params, v ResponseSetter) error {
+	if err := validateMethod(method); err != nil {
+		return err
+	}
+
+	req, err := t.NewRequest(method, path, key, "application/json", params)
+	if err != nil {
+		return err
+	}
+
+	responseSetter := metricsResponseSetter{
+		ResponseSetter: v,
+		transporter:    t,
+		params:         params,
+	}
+
+	if err := t.Do(req, bytes.NewBuffer(body), &responseSetter); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UnmarshalJSONVerbose unmarshals JSON, but in case of a failure logs and
+// produces a more descriptive error.
+func (s *transporterImplementation) UnmarshalJSONVerbose(statusCode int, body []byte, v interface{}) error {
+	err := json.Unmarshal(body, v)
+	if err != nil {
+		// If we got invalid JSON back then something totally unexpected is
+		// happening (caused by a bug on the server side). Put a sample of the
+		// response body into the error message so we can get a better feel for
+		// what the problem was.
+		bodySample := string(body)
+		if len(bodySample) > 500 {
+			bodySample = bodySample[0:500] + " ..."
+		}
+
+		// Make sure a multi-line response ends up all on one line
+		bodySample = strings.Replace(bodySample, "\n", "\\n", -1)
+
+		newErr := fmt.Errorf("Couldn't deserialize JSON (response status: %v, body sample: '%s'): %v",
+			statusCode, bodySample, err)
+		s.LeveledLogger.Errorf("%s", newErr.Error())
+		return newErr
+	}
+
+	return nil
+}
+
+// responseToError converts a SNAP response to an error.
+func (s *transporterImplementation) responseToError(res *http.Response, resBody []byte) error {
+	// First, we partially unmarshal just the error type
+	var raw struct {
+		Error *RawError `json:"error"`
+	}
+	if err := s.UnmarshalJSONVerbose(res.StatusCode, resBody, &raw); err != nil {
+		return err
+	}
+
+	// need to return a generic error in this case
+	if raw.Error == nil {
+		err := errors.New(string(resBody))
+		return err
+	}
+
+	return raw.Error
+}
+
+func (s *transporterImplementation) logError(statusCode int, err error) {
+	if snapErr, ok := err.(redacter); ok {
+		// The SNAP makes a distinction between errors that were
+		// caused by invalid parameters or something else versus those
+		// that occurred *despite* valid parameters, the latter coming
+		// back with status 402.
+		//
+		// On a 402, log to info so as to not make an integration's log
+		// noisy with error messages that they don't have much control
+		// over.
+		//
+		// Note I use the constant 402 instead of an `http.Status*`
+		// constant because technically 402 is "Payment required". The
+		// Snap doesn't comply to the letter of the specification
+		// and uses it in a broader sense.
+		if statusCode == 402 {
+			s.LeveledLogger.Infof("User-compelled request error from Snap (status %v): %v",
+				statusCode, snapErr.redact())
+		} else {
+			s.LeveledLogger.Errorf("Request error from Snap (status %v): %v",
+				statusCode, snapErr.redact())
+		}
+	} else {
+		s.LeveledLogger.Errorf("Error decoding error from Snap: %v", err)
+	}
+}
+
+func (s *transporterImplementation) maybeSetTelemetryHeader(req *http.Request) {
+	if s.enableTelemetry {
+		select {
+		case metrics := <-s.requestMetricsBuffer:
+			metricsJSON, err := json.Marshal(&requestTelemetry{LastRequestMetrics: metrics})
+			if err == nil {
+				req.Header.Set("X-Snap-Client-Telemetry", string(metricsJSON))
+			} else {
+				s.LeveledLogger.Warnf("Unable to encode client telemetry: %v", err)
+			}
+		default:
+			// There are no metrics available, so don't send any.
+			// This default case  needs to be here to prevent Do from blocking on an
+			// empty requestMetricsBuffer.
+		}
+	}
+}
+
+// NewRequest is used by Call to generate an http.Request. It handles encoding
+// parameters and attaching the appropriate headers.
+func (s *transporterImplementation) NewRequest(method, path, key, contentType string, params *Params) (*http.Request, error) {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	// Body is set later by `Do`.
+	req, err := http.NewRequest(method, s.URL+path, nil)
+	if err != nil {
+		s.LeveledLogger.Errorf("Cannot create SNAP request: %v", err)
+		return nil, err
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", key))
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+		if params.Context != nil {
+			req = req.WithContext(params.Context)
+		}
+
+		for k, v := range params.Headers {
+			for _, line := range v {
+				// Use Set to override the default value possibly set before
+				req.Header.Set(k, line)
+			}
+		}
+	}
+
+	return req, nil
+}
+
+// requestWithRetriesAndTelemetry uses s.HTTPClient to make an HTTP request,
+// and handles retries, telemetry, and emitting log statements.  It attempts to
+// avoid processing the *result* of the HTTP request. It receives a
+// "handleResponse" func from the caller, and it defers to that to determine
+// whether the request was a failure or success, and to convert the
+// response/error into the appropriate type of error or an appropriate result
+// type.
+func (s *transporterImplementation) requestWithRetriesAndTelemetry(
+	req *http.Request,
+	body *bytes.Buffer,
+	handleResponse func(*http.Response, error) (any, error),
+) (*http.Response, any, *time.Duration, error) {
+	s.LeveledLogger.Infof("Requesting %v %v%v", req.Method, req.URL.Host, req.URL.Path)
+	s.maybeSetTelemetryHeader(req)
+	var resp *http.Response
+	var err error
+	var requestDuration time.Duration
+	var result any
+	for retry := 0; ; {
+		start := time.Now()
+		resetBodyReader(body, req)
+
+		resp, err = s.HTTPClient.Do(req)
+
+		requestDuration = time.Since(start)
+		s.LeveledLogger.Infof("Request completed in %v (retry: %v)", requestDuration, retry)
+
+		result, err = handleResponse(resp, err)
+
+		// If the response was okay, or an error that shouldn't be retried,
+		// we're done, and it's safe to leave the retry loop.
+		shouldRetry, noRetryReason := s.shouldRetry(err, req, resp, retry)
+
+		if !shouldRetry {
+			s.LeveledLogger.Infof("Not retrying request: %v", noRetryReason)
+			break
+		}
+
+		sleepDuration := s.sleepTime(retry)
+		retry++
+
+		s.LeveledLogger.Warnf("Initiating retry %v for request %v %v%v after sleeping %v",
+			retry, req.Method, req.URL.Host, req.URL.Path, sleepDuration)
+
+		time.Sleep(sleepDuration)
+	}
+
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return resp, result, &requestDuration, nil
+}
+
+// Regular expressions used to match a few error types that we know we don't
+// want to retry. Unfortunately these errors aren't typed so we match on the
+// error's message.
+var (
+	redirectsErrorRE = regexp.MustCompile(`stopped after \d+ redirects\z`)
+	schemeErrorRE    = regexp.MustCompile(`unsupported protocol scheme`)
+)
+
+// Checks if an error is a problem that we should retry on. This includes both
+// socket errors that may represent an intermittent problem and some special
+// HTTP statuses.
+//
+// Returns a boolean indicating whether a client should retry. If false, a
+// second string parameter is also returned with a short message indicating why
+// no retry should occur. This can be used for logging/informational purposes.
+func (s *transporterImplementation) shouldRetry(err error, req *http.Request, resp *http.Response, numRetries int) (bool, string) {
+	if numRetries >= int(s.MaxNetworkRetries) {
+		return false, "max retries exceeded"
+	}
+
+	// Don't retry if the context was canceled or its deadline was exceeded.
+	if req.Context() != nil && req.Context().Err() != nil {
+		switch req.Context().Err() {
+		case context.Canceled:
+			return false, "context canceled"
+		case context.DeadlineExceeded:
+			return false, "context deadline exceeded"
+		default:
+			return false, fmt.Sprintf("unknown context error: %v", req.Context().Err())
+		}
+	}
+
+	// All errors from the Snap should implement the `retrier` interface.
+	// Any other error comes from a different layer
+	if err, ok := err.(retrier); ok {
+		return err.canRetry(), "not retriable error"
+	}
+
+	// We retry most errors that come out of HTTP requests except for a curated
+	// list that we know not to be retryable. This list is probably not
+	// exhaustive, so it'd be okay to add new errors to it. It'd also be okay to
+	// flip this to an inverted strategy of retrying only errors that we know
+	// to be retryable in a future refactor, if a good methodology is found for
+	// identifying that full set of errors.
+	if err != nil {
+		if urlErr, ok := err.(*url.Error); ok {
+			// Don't retry too many redirects.
+			if redirectsErrorRE.MatchString(urlErr.Error()) {
+				return false, urlErr.Error()
+			}
+
+			// Don't retry invalid protocol scheme.
+			if schemeErrorRE.MatchString(urlErr.Error()) {
+				return false, urlErr.Error()
+			}
+
+			// Don't retry TLS certificate validation problems.
+			if _, ok := urlErr.Err.(x509.UnknownAuthorityError); ok {
+				return false, urlErr.Error()
+			}
+		}
+
+		// Do retry every other type of non-Snap error.
+		return true, ""
+	}
+
+	// 409 Conflict
+	if resp.StatusCode == http.StatusConflict {
+		return true, ""
+	}
+
+	// Retry on 500, 503, and other internal errors.
+	//
+	// in most cases when a 500 is returned,
+	// would typically replay it anyway.
+	if resp.StatusCode >= http.StatusInternalServerError {
+		return true, ""
+	}
+
+	return false, "response not known to be safe for retry"
+}
+
+// defaultHTTPTimeout is the default timeout on the http.Client used by the library.
+const defaultHTTPTimeout = 80 * time.Second
+
+// maxNetworkRetriesDelay and minNetworkRetriesDelay defines sleep time in milliseconds between
+// tries to send HTTP request again after network failure.
+const maxNetworkRetriesDelay = 5000 * time.Millisecond
+const minNetworkRetriesDelay = 500 * time.Millisecond
+
+// The number of requestMetric objects to buffer for client telemetry. When the
+// buffer is full, new requestMetrics are dropped.
+const telemetryBufferSize = 16
+
+// sleepTime calculates sleeping/delay time in milliseconds between failure and a new one request.
+func (s *transporterImplementation) sleepTime(numRetries int) time.Duration {
+	// We disable sleeping in some cases for tests.
+	if !s.networkRetriesSleep {
+		return 0 * time.Second
+	}
+
+	// Apply exponential backoff with minNetworkRetriesDelay on the
+	// number of num_retries so far as inputs.
+	delay := minNetworkRetriesDelay + minNetworkRetriesDelay*time.Duration(numRetries*numRetries)
+
+	// Do not allow the number to exceed maxNetworkRetriesDelay.
+	if delay > maxNetworkRetriesDelay {
+		delay = maxNetworkRetriesDelay
+	}
+
+	// Apply some jitter by randomizing the value in the range of 75%-100%.
+	jitter := rand.Int63n(int64(delay / 4))
+	delay -= time.Duration(jitter)
+
+	// But never sleep less than the base sleep seconds.
+	if delay < minNetworkRetriesDelay {
+		delay = minNetworkRetriesDelay
+	}
+
+	return delay
+}
+
+// Do is used by Call to execute an API request and parse the response. It uses
+// the backend's HTTP client to execute the request and unmarshals the response
+// into v. It also handles unmarshaling errors returned by the API.
+func (s *transporterImplementation) Do(req *http.Request, body *bytes.Buffer, v ResponseSetter) error {
+	handleResponse := func(res *http.Response, err error) (interface{}, error) {
+		var resBody []byte
+		if err == nil {
+			resBody, err = ioutil.ReadAll(res.Body)
+			res.Body.Close()
+		}
+
+		switch {
+		case err != nil:
+			s.LeveledLogger.Errorf("Request failed with error: %v", err)
+		case res.StatusCode >= 400:
+			err = s.responseToError(res, resBody)
+			s.logError(res.StatusCode, err)
+		}
+
+		return resBody, err
+	}
+
+	res, result, requestDuration, err := s.requestWithRetriesAndTelemetry(req, body, handleResponse)
+	if err != nil {
+		return err
+	}
+	resBody := result.([]byte)
+	s.LeveledLogger.Debugf("Response: %s", string(resBody))
+
+	err = s.UnmarshalJSONVerbose(res.StatusCode, resBody, v)
+	v.SetResponse(newAPIResponse(res, resBody, requestDuration))
+	return err
+}
+
+func (t *transporterImplementation) maybeEnqueueTelemetryMetrics(requestID string, requestDuration *time.Duration, usage []string) {
+	if !t.enableTelemetry || requestID == "" {
+		return
+	}
+
+	// If there's no duration to report and no usage to report, don't bother
+	if requestDuration == nil && len(usage) == 0 {
+		return
+	}
+
+	metrics := requestMetrics{
+		RequestID: requestID,
+	}
+
+	if requestDuration != nil {
+		requestDurationMS := int(*requestDuration / time.Millisecond)
+		metrics.RequestDurationMS = &requestDurationMS
+	}
+
+	if len(usage) > 0 {
+		metrics.Usage = usage
+	}
+
+	select {
+	case t.requestMetricsBuffer <- metrics:
+	default:
+	}
+}
+
+// ResponseSetter defines a type that contains an HTTP response from a SNAP
+type ResponseSetter interface {
+	SetResponse(response *APIResponse)
+}
+
+// UsageTransporter is a wrapper for snap.Transporter that sets the usage parameter
+type UsageTransporter struct {
+	T     Transporter
+	Usage []string
+}
+
+func (u UsageTransporter) Call(method, path, key string, params ParamsContainer, response ResponseSetter) error {
+	if r := reflect.ValueOf(params); r.Kind() == reflect.Ptr && !r.IsNil() {
+		params.GetParams().InternalSetUsage(u.Usage)
+	}
+
+	return u.T.Call(method, path, key, params, response)
+}
+
+type metricsResponseSetter struct {
+	ResponseSetter
+	transporter *transporterImplementation
+	params      *Params
+}
+
+func (s *metricsResponseSetter) SetResponse(response *APIResponse) {
+	var usage []string
+	if s.params != nil {
+		usage = s.params.usage
+	}
+	s.transporter.maybeEnqueueTelemetryMetrics(response.RequestID, response.duration, usage)
+	s.ResponseSetter.SetResponse(response)
+}
+
+func (s *metricsResponseSetter) UnmarshalJSON(b []byte) error {
+	return json.Unmarshal(b, s.ResponseSetter)
+}

--- a/snap_client.go
+++ b/snap_client.go
@@ -1,0 +1,70 @@
+package snap
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"time"
+)
+
+type Client struct {
+	PrivateKey string
+	ClientID   string
+}
+
+func NewClient(privateKey, clientID string) (c *Client, err error) {
+	client := &Client{
+		PrivateKey: privateKey,
+		ClientID:   clientID,
+	}
+
+	if _, err := client.generateSignature(); err != nil {
+		return c, err
+	}
+
+	return client, nil
+}
+
+func (c *Client) generateSignature() (signature string, err error) {
+	block, _ := pem.Decode([]byte(c.PrivateKey))
+	if block == nil {
+		return signature, errors.New("failed to decode PEM block containing private key")
+	}
+
+	var rsaPrivateKey *rsa.PrivateKey
+	switch block.Type {
+	case "PRIVATE KEY":
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return signature, fmt.Errorf("parse PKCS#8 private key: %w", err)
+		}
+		var ok bool
+		if rsaPrivateKey, ok = key.(*rsa.PrivateKey); !ok {
+			return signature, errors.New("private key is not RSA")
+		}
+	case "RSA PRIVATE KEY":
+		key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return signature, fmt.Errorf("parse PKCS#1 private key: %w", err)
+		}
+		rsaPrivateKey = key
+	default:
+		return signature, fmt.Errorf("unsupported private key type: %s", block.Type)
+	}
+
+	payload := fmt.Sprintf("%s|%s", c.ClientID, time.Now().Format(time.RFC3339))
+	hash := sha256.Sum256([]byte(payload))
+
+	generatedSignature, err := rsa.SignPKCS1v15(rand.Reader, rsaPrivateKey, crypto.SHA256, hash[:])
+	if err != nil {
+		return signature, fmt.Errorf("signing failed: %w", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(generatedSignature), nil
+}


### PR DESCRIPTION
# Add Transporter and Snap Client

## Summary
This PR introduces the `Transporter` and `Snap` client to support secure communication with the Snap API. It ensures proper initialization and verification of the client's private key during startup.

## Changes
- **Added `Transporter` abstraction** for handling API requests/responses with clean, testable interface
- **Implemented `Snap` client** for secure interactions with Snap APIs
- **Added client verification** (`VerifyClientKey`) to validate RSA private keys on startup